### PR TITLE
Support for macOS Debugger lldb in VSCode

### DIFF
--- a/doc/wiki/Developing-with-VS-Code.md
+++ b/doc/wiki/Developing-with-VS-Code.md
@@ -51,7 +51,8 @@ After configuring GAMER with [configure.py](https://github.com/gamer-project/gam
 To start debugging GAMER, select `Run` > `Start Debugging` or press `F5`. After enter the working directory, the debugger will be launched. See the [official documentation](https://code.visualstudio.com/docs/editor/debugging) to learn more about debugging with VS Code.
 
 > [!NOTE]  
-> If you are using macOS and `gdb` is not supported, then you need to setup `lldb` as the debugger in `launch.json` by yourself. You can refer to the [official documentation](https://code.visualstudio.com/docs/cpp/launch-json-reference) for more information.
+> If `gdb` is not supported on macOS, you can set up `lldb` as the debugger. Make sure [`lldb-mi`](https://github.com/lldb-tools/lldb-mi) is installed. Then select `Terminal` > `Run Task...` > `updated_mac_launch`. This task updates the debugger path in `launch.json` to your `lldb-mi` installation.
+> For manual setup or additional details, refer to the [official documentation](https://code.visualstudio.com/docs/cpp/launch-json-reference).
 
 ### Clean working directory
 

--- a/tool/vscode/tasks.json
+++ b/tool/vscode/tasks.json
@@ -46,6 +46,20 @@
             },
             "detail": "Choose the working directory for the binary files.",
             "problemMatcher": []
+        },
+        {
+            "label": "updated_mac_launch",
+            "type": "shell",
+            "command": "sh",
+            "args": [
+                "updated_mac_launch.sh",
+                "${input:lldb-mi_path}"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}/.vscode"
+            },
+            "detail": "Update launch.json with the path to your lldb-mi executable for mac user.",
+            "problemMatcher": []
         }
     ],
     "inputs": [
@@ -53,6 +67,11 @@
             "id": "bin-working",
             "type": "promptString",
             "description": "Enter the working directory under bin/."
+        },
+        {
+            "id": "lldb-mi_path",
+            "type": "promptString",
+            "description": "Enter the path to your lldb-mi executable."
         }
     ],
     "version": "2.0.0"

--- a/tool/vscode/updated_mac_launch.sh
+++ b/tool/vscode/updated_mac_launch.sh
@@ -18,16 +18,33 @@ else
     read lldb_mi_path
 fi
 
+# Parameters to change
+MIMODE="lldb"
+MIDEBUGGERPATH=$lldb_mi_path
+MIDEBUGGERARGS="-q"
+
 # Input file
 INPUT_FILE="launch.json"
 
 # Replace MIMode from "gdb" to "lldb"
-sed -i '' 's/"MIMode": "gdb"/"MIMode": "lldb"/' "$INPUT_FILE"
+if grep -q "\"MIMode\": \"$MIMODE\"" "$INPUT_FILE"; then
+    echo "Warning: 'MIMode' is already set to '$MIMODE'."
+else
+    sed -i '' 's/"MIMode": "gdb"/"MIMode": "'"$MIMODE"'"/' "$INPUT_FILE"
+    echo "'MIMode' changed to '$MIMODE'."
+fi
 
 # Replace miDebuggerPath to the new path
-sed -i '' 's|"miDebuggerPath": "/usr/bin/gdb"|"miDebuggerPath": "$lldb_mi_path"|' "$INPUT_FILE"
+sed -i '' 's|"miDebuggerPath": .*|"miDebuggerPath": "'"$MIDEBUGGERPATH"'",|' "$INPUT_FILE"
+echo "'miDebuggerPath' changed to '$MIDEBUGGERPATH'."
+
 
 # Replace miDebuggerArgs to "-q"
-sed -i '' 's/"miDebuggerArgs": "-quiet"/"miDebuggerArgs": "-q"/' "$INPUT_FILE"
+if grep -q "\"miDebuggerArgs\": \"$MIDEBUGGERARGS\"" "$INPUT_FILE"; then
+    echo "Warning: 'miDebuggerArgs' is already set to '$MIDEBUGGERARGS'."
+else
+    sed -i '' 's/"miDebuggerArgs": "-quiet"/"miDebuggerArgs": "'"$MIDEBUGGERARGS"'"/' "$INPUT_FILE"
+    echo "'miDebuggerArgs' changed to '$MIDEBUGGERARGS'."
+fi
 
 echo "launch.json updated successfully."

--- a/tool/vscode/updated_mac_launch.sh
+++ b/tool/vscode/updated_mac_launch.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Check OS
+if [ "$(uname)" == "Darwin" ]; then
+    echo "OS: macOS. Start updating launch.json..."
+else
+    echo "OS: Linux. Do nothing."
+    exit 0
+fi
+
+cd "$(dirname "$0")"
+
+# If $1 is given, use it as $lldb_mi_path, else prompt the user
+if [ -n "$1" ]; then
+    lldb_mi_path="$1"
+else
+    echo -n "Enter your lldb-mi path. (e.g. /Users/user_namer/lldb-mi/build/src/lldb-mi): "
+    read lldb_mi_path
+fi
+
+# Input file
+INPUT_FILE="launch.json"
+
+# Replace MIMode from "gdb" to "lldb"
+sed -i '' 's/"MIMode": "gdb"/"MIMode": "lldb"/' "$INPUT_FILE"
+
+# Replace miDebuggerPath to the new path
+sed -i '' 's|"miDebuggerPath": "/usr/bin/gdb"|"miDebuggerPath": "$lldb_mi_path"|' "$INPUT_FILE"
+
+# Replace miDebuggerArgs to "-q"
+sed -i '' 's/"miDebuggerArgs": "-quiet"/"miDebuggerArgs": "-q"/' "$INPUT_FILE"
+
+echo "launch.json updated successfully."


### PR DESCRIPTION
This pull request adds support for debugging on macOS in `VSCode` for setting up `lldb` as the debugger when `gdb `is not supported.
1. new task `updated_mac_launch` added
2. update wiki

I have tested this on my Mac (M1 chip) and @Chen-ChunYen's Mac (Intel chip), and it works on both.
Please let me know if you have any suggestions or feedback!